### PR TITLE
split out service so we can use file standalone

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -35,6 +35,10 @@ define apache_httpd::file (
   $source  = undef,
   $content = undef,
 ) {
+
+  include ::apache_httpd::install
+  include ::apache_httpd::service
+
   file { "${confd}/${title}":
     ensure  => $ensure,
     owner   => $owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,9 @@ class apache_httpd (
 ) inherits ::apache_httpd::params {
 
   include '::apache_httpd::install'
+  class { '::apache_httpd::service':
+    service_restart => $service_restart
+  }
 
   # Our own pre-configured file (disable nearly everything)
   file { '/etc/httpd/conf/httpd.conf':
@@ -146,14 +149,6 @@ class apache_httpd (
     content => template("${module_name}/logrotate.erb"),
   }
 
-  # Main service
-  service { 'httpd':
-    ensure    => running,
-    enable    => true,
-    restart   => $service_restart,
-    hasstatus => true,
-    require   => Package['httpd'],
-  }
   if $ssl {
     package { 'mod_ssl':
       ensure => installed,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,19 @@
+# Class: apache_httpd::service
+#
+# Apache httpd web server service class.
+#
+class apache_httpd::service (
+  $service_restart        = $::apache_httpd::params::service_restart,
+) {
+
+  include '::apache_httpd::install'
+
+  # Main service
+  service { 'httpd':
+    ensure    => running,
+    enable    => true,
+    restart   => $service_restart,
+    hasstatus => true,
+    require   => Package['httpd'],
+  }
+}


### PR DESCRIPTION
I wanted to be able to do apache_httpd::file from a profile module for wordpress.  I don't want that module to set up httpd as that is done in a different profile module, I just want it to drop in the config file for its part of apache's config.